### PR TITLE
Add logic to display no tabs when there are no collections

### DIFF
--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -27,21 +27,25 @@
             .text-muted.d-inline.font-weight-normal
                 = @user.bio
     %hr
-    %ul#pills-tab.nav.nav-pills.mb-3{:role => "tablist"}
-        %li.nav-item
-            %a#pills-home-tab.nav-link.active{"aria-controls" => "pills-home", "aria-selected" => "true", "data-toggle" => "pill", :href => "#pills-home", :role => "tab"} Posts
-        %li.nav-item
-            %a#pills-profile-tab.nav-link{"aria-controls" => "pills-profile", "aria-selected" => "false", "data-toggle" => "pill", :href => "#pills-profile", :role => "tab"} Collections
-    #pills-tabContent.tab-content
-        #pills-home.tab-pane.fade.show.active{"aria-labelledby" => "pills-home-tab", :role => "tabpanel"}
-            .row
-                -if @posts.empty?
-                    %p This user does not have any posts yet
-                -else
-                    = render @posts
-        #pills-profile.tab-pane.fade{"aria-labelledby" => "pills-profile-tab", :role => "tabpanel"}
-            .row
-                -if @collections.empty?
-                    %p This user does not have any collections yet
-                -else
+    -unless @collections.empty?
+        %ul#pills-tab.nav.nav-pills.mb-3{:role => "tablist"}
+            %li.nav-item
+                %a#pills-home-tab.nav-link.active{"aria-controls" => "pills-home", "aria-selected" => "true", "data-toggle" => "pill", :href => "#pills-home", :role => "tab"} Posts
+            %li.nav-item
+                %a#pills-profile-tab.nav-link{"aria-controls" => "pills-profile", "aria-selected" => "false", "data-toggle" => "pill", :href => "#pills-profile", :role => "tab"} Collections
+        #pills-tabContent.tab-content
+            #pills-home.tab-pane.fade.show.active{"aria-labelledby" => "pills-home-tab", :role => "tabpanel"}
+                .row
+                    -if @posts.empty?
+                        %p This user does not have any posts yet
+                    -else
+                        = render @posts
+            #pills-profile.tab-pane.fade{"aria-labelledby" => "pills-profile-tab", :role => "tabpanel"}
+                .row
                     = render @collections
+    -else
+        .row
+            -if @posts.empty?
+                %p This user does not have any posts yet
+            -else
+                = render @posts


### PR DESCRIPTION
In the situation when a user has no collections, I think showing tabs is not necessary. I added a little bit of logic that deals with the bespoke situation. What do you think?