### PR TITLE
Fix acts as taggable migration

### DIFF
--- a/db/migrate/20210219175652_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210219175652_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -8,28 +8,18 @@ else
 end
 AddMissingIndexesOnTaggings.class_eval do
   def change
-    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? 
-ActsAsTaggableOn.taggings_table, :tag_id
-    add_index ActsAsTaggableOn.taggings_table, 
-:taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                 :taggable_id
-    add_index ActsAsTaggableOn.taggings_table, 
-:taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                   :taggable_type
-    add_index ActsAsTaggableOn.taggings_table, 
-:tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                               :tagger_id
-    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? 
-ActsAsTaggableOn.taggings_table, :context
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
 
     unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
       add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
     end
 
-    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
-                         name: 'taggings_idy'
-      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
-                name: 'taggings_idy'
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
     end
   end
 end


### PR DESCRIPTION
After cloning unframed code onto a new device, setting up the database, and running migrations, I figured out that rubocop had messed up AddMissingIndexesOnTaggings migration syntax (broke longer lines into smaller ones).
Here is the fix for it so we don't have to encounter the same problem in the future.